### PR TITLE
Add recordings/compositions endpoint

### DIFF
--- a/omi_api/views/compositions.py
+++ b/omi_api/views/compositions.py
@@ -39,7 +39,7 @@ class CompositionListApi(Resource):
                             location='json')
         parser.add_argument('publishers', type=list, required=True,
                             location='json')
-        parser.add_argument('iswc', type=str, required=True,
+        parser.add_argument('iswc', type=str, required=False,
                             location='json')
         args = parser.parse_args()
 

--- a/omi_api/views/recordings_compositions.py
+++ b/omi_api/views/recordings_compositions.py
@@ -23,7 +23,6 @@ from omi_api.queries import bdb_find, unpack
 bdb = BigchainDB(get_bigchaindb_api_url())
 
 recordings_compositions_views = Blueprint('recordings_compositions_views',
-
                                           __name__)
 recordings_compositions_api = Api(recordings_compositions_views)
 


### PR DESCRIPTION
Add `recordings/compositions` endpoint to:
- Create new connections between recordings and compositions using the `isrc` and `iswc` codes.
- Retrieve recordings connected to a composition.
- Retrieve compositions connected to a recording.